### PR TITLE
Fehler auf Setup Seite, wenn kein Imagick vorhanden

### DIFF
--- a/pages/media_manager.media_negotiator.setup.php
+++ b/pages/media_manager.media_negotiator.setup.php
@@ -28,6 +28,7 @@ if (class_exists(Imagick::class)) {
     echo "<p>Imagick Version: " . $imagickVersion . "</p>";
 } else {
     echo '<p class="text-danger bold"><b>Imagick ist nicht installiert</b></p>';
+    $imagickFormats = [];
 }
 
 if (function_exists('imageavif')) {


### PR DESCRIPTION
Wenn Imagick nicht vorhanden gibt es einen Fehler:

in_array(): Argument #2 ($haystack) must be of type array, null given  

/redaxo/src/addons/media_negotiator/pages/media_manager.media_negotiator.setup.php 51