### PR TITLE
Remove imagedestroy calls for webp and avif images

### DIFF
--- a/pages/media_manager.media_negotiator.setup.php
+++ b/pages/media_manager.media_negotiator.setup.php
@@ -110,7 +110,6 @@ if (function_exists('imagewebp')) {
     imagewebp($image);
     $imageData = ob_get_contents();
     ob_end_clean();
-    imagedestroy($image);
     $size_imagewebp = strlen($imageData) / 1000;
     $img_imagewebp = '<img class="img-thumbnail" src="data:image/webp;base64,' . base64_encode($imageData) . '">';
 } else {
@@ -123,7 +122,6 @@ if (function_exists('imageavif')) {
     imageavif($image);
     $imageData = ob_get_contents();
     ob_end_clean();
-    imagedestroy($image);
     $size_imageavif = strlen($imageData) / 1000;
     $img_imageavif = '<img class="img-thumbnail" src="data:image/webp;base64,' . base64_encode($imageData) . '">';
 } else {


### PR DESCRIPTION
Deprecated: Function imagedestroy() is deprecated since PHP 8.5, as it has no effect since PHP 8.0

Removed unnecessary imagedestroy calls after generating image data for webp and avif formats to avoid deprecation notice.