### PR TITLE
Prefer GD for AVIF so the quality setting is honoured (Imagick AVIF ignores it on some builds)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- **AVIF-Qualität wird auf betroffenen ImageMagick-Builds respektiert**: Für AVIF wird nun GD (`imageavif`) vor Imagick versucht. Mehrere ImageMagick-Builds (mit bestimmten libheif/libaom-Versionen) ignorieren die AVIF-Kompressionsqualität komplett und liefern unabhängig vom eingestellten Wert immer eine stark überkomprimierte Datei; GD setzt die Qualität korrekt um. Für WebP bleibt Imagick bevorzugt.
+
+### Added
+- `Helper::gdConvert()` als dritter Converter neben vips und Imagick. Damit können Server, auf denen nur GD verfügbar ist (kein vips, kein Imagick), wieder AVIF/WebP erzeugen.
+
 ## [6.2.2] - 2026-06-29
 
 ### Fixed

--- a/lib/Helper.php
+++ b/lib/Helper.php
@@ -455,4 +455,57 @@ class Helper
             $imagick->destroy();
         }
     }
+
+    /**
+     * Convert an image blob to AVIF/WebP using GD.
+     *
+     * GD is a valuable third converter next to vips and Imagick:
+     *
+     *  - On servers that only ship GD (no vips, no Imagick) it is currently the
+     *    only way to produce AVIF/WebP at all – previously nothing converted.
+     *  - For AVIF it is often the more reliable choice: several ImageMagick
+     *    builds backed by certain libheif/libaom versions IGNORE the compression
+     *    quality entirely (every quality level yields the same, heavily
+     *    over-compressed file), whereas GD's imageavif() honours the quality
+     *    parameter across the full range.
+     *
+     * @param string $blob         Raw image data (already resized by the effect chain)
+     * @param string $targetFormat 'avif' or 'webp'
+     * @param int    $quality      0–100, or -1 for the encoder default
+     */
+    public static function gdConvert(string $blob, string $targetFormat, int $quality = -1): string|false
+    {
+        if ('avif' === $targetFormat && (!function_exists('imageavif') || !self::gdSupportsAvif())) {
+            return false;
+        }
+        if ('webp' === $targetFormat && !function_exists('imagewebp')) {
+            return false;
+        }
+        if (!in_array($targetFormat, ['avif', 'webp'], true)) {
+            return false;
+        }
+
+        $img = @imagecreatefromstring($blob);
+        if (false === $img) {
+            return false;
+        }
+
+        try {
+            imagepalettetotruecolor($img);
+            imagealphablending($img, false);
+            imagesavealpha($img, true);
+
+            ob_start();
+            if ('avif' === $targetFormat) {
+                $ok = imageavif($img, null, $quality >= 0 ? $quality : 60);
+            } else {
+                $ok = imagewebp($img, null, $quality >= 0 ? $quality : 80);
+            }
+            $out = ob_get_clean();
+
+            return ($ok && is_string($out) && '' !== $out) ? $out : false;
+        } finally {
+            imagedestroy($img);
+        }
+    }
 }

--- a/lib/Helper.php
+++ b/lib/Helper.php
@@ -497,9 +497,9 @@ class Helper
 
             ob_start();
             if ('avif' === $targetFormat) {
-                $ok = imageavif($img, null, $quality >= 0 ? $quality : 60);
+                $ok = imageavif($img, null, $quality >= 0 ? $quality : -1);
             } else {
-                $ok = imagewebp($img, null, $quality >= 0 ? $quality : 80);
+                $ok = imagewebp($img, null, $quality >= 0 ? $quality : -1);
             }
             $out = ob_get_clean();
 

--- a/lib/rex_effect_negotiator.php
+++ b/lib/rex_effect_negotiator.php
@@ -63,8 +63,16 @@ class rex_effect_negotiator extends rex_effect_abstract
             return;
         }
 
-        // Try converters in order: vips → imagick → original
-        $converters = ['vips', 'imagick'];
+        // Converter order.
+        // For AVIF, GD is tried before Imagick: several ImageMagick builds (backed
+        // by certain libheif/libaom versions) ignore the AVIF compression quality
+        // entirely and always emit a heavily over-compressed file, whereas GD's
+        // imageavif() honours the quality. For WebP, Imagick is kept first (its
+        // WebP quality works reliably). GD also acts as a fallback on servers that
+        // only ship GD (no vips, no Imagick), where previously nothing converted.
+        $converters = ($targetFormat === 'avif')
+            ? ['vips', 'gd', 'imagick']
+            : ['vips', 'imagick', 'gd'];
 
         foreach ($converters as $converter) {
             $result = false;
@@ -72,6 +80,19 @@ class rex_effect_negotiator extends rex_effect_abstract
             if ($converter === 'vips' && Helper::vipsPossible()) {
                 try {
                     $result = Helper::vipsConvert($sourceBlob, $targetFormat, $quality);
+                    if (is_string($result)) {
+                        // Blob output - write to temp and set as source path
+                        $this->setSourceFromBlob($result, $targetFormat);
+                        return;
+                    }
+                } catch (\Throwable) {
+                    // Continue to next converter
+                }
+            }
+
+            if ($converter === 'gd') {
+                try {
+                    $result = Helper::gdConvert($sourceBlob, $targetFormat, $quality);
                     if (is_string($result)) {
                         // Blob output - write to temp and set as source path
                         $this->setSourceFromBlob($result, $targetFormat);
@@ -96,7 +117,7 @@ class rex_effect_negotiator extends rex_effect_abstract
             }
         }
 
-        // All converters failed, keep original image (no GD fallback)
+        // All converters failed, keep original image
     }
 
     private function setSourceFromBlob(string $blob, string $format): void


### PR DESCRIPTION
## Problem

On some servers the AVIF output is heavily over-compressed and blurry **regardless of the configured `avif_quality`** – setting it to 10 or 100 produces the exact same result.

Root cause: on several **ImageMagick** builds (backed by certain **libheif/libaom** versions) the AVIF encoder **ignores the compression quality entirely**. Since 6.2.2 the negotiator only uses `vips → imagick` (GD was intentionally dropped), so on a server without vips every AVIF goes through the affected Imagick path.

### Evidence (real server: ImageMagick 7.1.2-23 Q16, image resized to 1600×900)

| Encoder | q≈20 | q≈50 | q≈90 | q=100 |
|---|---|---|---|---|
| **Imagick AVIF** | 21.1 KB | 21.1 KB | 21.1 KB | 21.1 KB — quality **ignored** |
| **GD AVIF** (`imageavif`) | 5.1 KB | 13.3 KB | 156.9 KB | 1515 KB — quality honoured ✅ |
| Imagick WebP | – | 28.2 KB | 90.6 KB | – (works fine) |

`setOption('heic:quality', …)` makes no difference either. So this is not a config or PHP-side issue – the Imagick AVIF delegate simply does not apply the quality on these builds.

## Fix

- Re-introduce a GD converter: `Helper::gdConvert()` for `avif`/`webp`.
- Converter order:
  - **AVIF** → `['vips', 'gd', 'imagick']` (GD before the affected Imagick path)
  - **WebP** → `['vips', 'imagick', 'gd']` (Imagick WebP quality works; GD as fallback)

This also restores conversion on **GD-only servers** (no vips, no Imagick), where nothing was converted after the 6.2.2 refactor.

Verified on the affected server: generated files now carry the `libavif` signature (GD/libaom) and the quality scales correctly across the full range.

## Notes

- I'm aware GD was deliberately removed in 6.2.2 for simplification. This PR re-adds it narrowly and for a concrete reason (quality bug + GD-only support), not as a general decode fallback.
- WebP behaviour is unchanged for servers with vips/Imagick.
- Happy to instead gate the AVIF→GD preference behind a config option (e.g. `avif_converter`) if you'd prefer to keep Imagick the default – just let me know.
